### PR TITLE
DEP Remove modules that have no tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,144 +1,141 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
     <!-- Core SilverStripe modules (except framework) -->
-    <testsuite name="recipe-core">
-        <directory>vendor/silverstripe/config/tests</directory>
-        <directory>vendor/silverstripe/assets/tests/php/</directory>
-        <directory>vendor/silverstripe/versioned/tests/php/</directory>
-    </testsuite>
+    <testsuites>
+        <testsuite name="recipe-core">
+            <directory>vendor/silverstripe/config/tests</directory>
+            <directory>vendor/silverstripe/assets/tests/php/</directory>
+            <directory>vendor/silverstripe/versioned/tests/php/</directory>
+        </testsuite>
 
-    <!-- Framework ORM tests are split up to run in parallel -->
-    <testsuite name="framework-orm">
-        <directory>vendor/silverstripe/framework/tests/php/ORM</directory>
-    </testsuite>
-    <testsuite name="framework-core">
-        <directory>vendor/silverstripe/framework/tests/php/Control</directory>
-        <directory>vendor/silverstripe/framework/tests/php/Core</directory>
-        <directory>vendor/silverstripe/framework/tests/php/Dev</directory>
-        <directory>vendor/silverstripe/framework/tests/php/Forms</directory>
-        <directory>vendor/silverstripe/framework/tests/php/Logging</directory>
-        <directory>vendor/silverstripe/framework/tests/php/Security</directory>
-        <directory>vendor/silverstripe/framework/tests/php/View</directory>
-        <directory>vendor/silverstripe/framework/tests/php/i18n</directory>
-    </testsuite>
+        <!-- Framework ORM tests are split up to run in parallel -->
+        <testsuite name="framework-orm">
+            <directory>vendor/silverstripe/framework/tests/php/ORM</directory>
+        </testsuite>
+        <testsuite name="framework-core">
+            <directory>vendor/silverstripe/framework/tests/php/Control</directory>
+            <directory>vendor/silverstripe/framework/tests/php/Core</directory>
+            <directory>vendor/silverstripe/framework/tests/php/Dev</directory>
+            <directory>vendor/silverstripe/framework/tests/php/Forms</directory>
+            <directory>vendor/silverstripe/framework/tests/php/Logging</directory>
+            <directory>vendor/silverstripe/framework/tests/php/Security</directory>
+            <directory>vendor/silverstripe/framework/tests/php/View</directory>
+            <directory>vendor/silverstripe/framework/tests/php/i18n</directory>
+        </testsuite>
 
-    <testsuite name="recipe-cms">
-        <directory>vendor/silverstripe/admin/tests/php/</directory>
-        <directory>vendor/silverstripe/campaign-admin/tests/php/</directory>
-        <directory>vendor/silverstripe/asset-admin/tests/php/</directory>
-        <directory>vendor/silverstripe/graphql/tests/</directory>
-        <directory>vendor/silverstripe/siteconfig/tests/php/</directory>
-        <directory>vendor/silverstripe/reports/tests/</directory>
-        <!-- CMS needs to run last because the SearchFormTest enables FulltextSearchable  -->
-        <directory>vendor/silverstripe/cms/tests/</directory>
-    </testsuite>
+        <testsuite name="recipe-cms">
+            <directory>vendor/silverstripe/admin/tests/php/</directory>
+            <directory>vendor/silverstripe/campaign-admin/tests/php/</directory>
+            <directory>vendor/silverstripe/asset-admin/tests/php/</directory>
+            <directory>vendor/silverstripe/graphql/tests/</directory>
+            <directory>vendor/silverstripe/siteconfig/tests/php/</directory>
+            <directory>vendor/silverstripe/reports/tests/</directory>
+            <!-- CMS needs to run last because the SearchFormTest enables FulltextSearchable  -->
+            <directory>vendor/silverstripe/cms/tests/</directory>
+        </testsuite>
 
-    <!-- Optional CWP modules that aren't in recipes -->
-    <testsuite name="Default">
-        <directory>mysite/tests</directory>
-        <directory>vendor/cwp/agency-extensions/tests</directory>
-        <directory>vendor/silverstripe/subsites/tests</directory>
-        <directory>vendor/silverstripe/ckan-registry/tests</directory>
-        <directory>vendor/silverstripe/controllerpolicy/tests</directory>
-        <directory>vendor/silverstripe/crontask/tests</directory>
-        <directory>vendor/silverstripe/gridfieldqueuedexport/tests</directory>
-        <directory>vendor/silverstripe/registry/tests</directory>
-        <directory>vendor/silverstripe/textextraction/tests</directory>
-        <directory>vendor/tractorcow/silverstripe-fluent/tests</directory>
-    </testsuite>
+        <!-- Optional CWP modules that aren't in recipes -->
+        <testsuite name="Default">
+            <directory>mysite/tests</directory>
+            <directory>vendor/cwp/agency-extensions/tests</directory>
+            <directory>vendor/silverstripe/subsites/tests</directory>
+            <directory>vendor/silverstripe/ckan-registry/tests</directory>
+            <directory>vendor/silverstripe/crontask/tests</directory>
+            <directory>vendor/silverstripe/gridfieldqueuedexport/tests</directory>
+            <directory>vendor/silverstripe/registry/tests</directory>
+            <directory>vendor/silverstripe/textextraction/tests</directory>
+            <directory>vendor/tractorcow/silverstripe-fluent/tests</directory>
+        </testsuite>
 
-    <!-- Core CWP recipes -->
-    <testsuite name="recipe-ccl">
-        <directory>vendor/cwp/cwp-core/tests</directory>
-        <directory>vendor/silverstripe/auditor/tests</directory>
-        <directory>vendor/silverstripe/environmentcheck/tests</directory>
-        <directory>vendor/silverstripe/hybridsessions/tests</directory>
-        <directory>vendor/silverstripe/mimevalidator/tests</directory>
-    </testsuite>
+        <!-- Core CWP recipes -->
+        <testsuite name="cwp-recipe-core">
+            <directory>vendor/cwp/cwp-core/tests</directory>
+            <directory>vendor/silverstripe/auditor/tests</directory>
+            <directory>vendor/silverstripe/environmentcheck/tests</directory>
+            <directory>vendor/silverstripe/hybridsessions/tests</directory>
+            <directory>vendor/silverstripe/mimevalidator/tests</directory>
+        </testsuite>
 
-    <testsuite name="cwp-recipe-cms">
-        <directory>vendor/cwp/cwp-core/tests</directory>
-        <directory>vendor/cwp/cwp/tests</directory>
-        <directory>vendor/cwp/cwp-pdfexport/tests</directory>
-        <directory>vendor/silverstripe/html5/tests</directory>
-        <directory>vendor/symbiote/silverstripe-gridfieldextensions/tests</directory>
-        <directory>vendor/symbiote/silverstripe-errorpage/tests</directory>
-    </testsuite>
+        <testsuite name="cwp-recipe-cms">
+            <directory>vendor/cwp/cwp-core/tests</directory>
+            <directory>vendor/cwp/cwp/tests</directory>
+            <directory>vendor/cwp/cwp-pdfexport/tests</directory>
+            <directory>vendor/silverstripe/html5/tests</directory>
+            <directory>vendor/symbiote/silverstripe-gridfieldextensions/tests</directory>
+        </testsuite>
 
-    <testsuite name="recipe-solr-search">
-        <directory>vendor/cwp/cwp</directory>
-        <directory>vendor/cwp/cwp-search/tests</directory>
-        <directory>vendor/silverstripe/fulltextsearch/tests</directory>
-        <directory>vendor/symbiote/silverstripe-queuedjobs/tests</directory>
-    </testsuite>
+        <testsuite name="cwp-recipe-search">
+            <directory>vendor/cwp/cwp</directory>
+            <directory>vendor/cwp/cwp-search/tests</directory>
+            <directory>vendor/silverstripe/fulltextsearch/tests</directory>
+            <directory>vendor/symbiote/silverstripe-queuedjobs/tests</directory>
+        </testsuite>
 
-    <!-- Optional SilverStripe recipes -->
-    <testsuite name="recipe-authoring-tools">
-        <directory>vendor/silverstripe/documentconverter/tests</directory>
-        <directory>vendor/silverstripe/iframe/tests</directory>
-        <directory>vendor/silverstripe/spellcheck/tests</directory>
-        <directory>vendor/silverstripe/tagfield/tests</directory>
-        <directory>vendor/silverstripe/taxonomy/tests</directory>
-    </testsuite>
+        <!-- Optional SilverStripe recipes -->
+        <testsuite name="recipe-authoring-tools">
+            <directory>vendor/silverstripe/documentconverter/tests</directory>
+            <directory>vendor/silverstripe/iframe/tests</directory>
+            <directory>vendor/silverstripe/spellcheck/tests</directory>
+            <directory>vendor/silverstripe/tagfield/tests</directory>
+            <directory>vendor/silverstripe/taxonomy/tests</directory>
+        </testsuite>
 
-    <testsuite name="recipe-blog">
-        <directory>vendor/silverstripe/blog/tests</directory>
-        <directory>vendor/silverstripe/lumberjack/tests</directory>
-        <directory>vendor/silverstripe/widgets/tests</directory>
-        <directory>vendor/silverstripe/content-widget/tests</directory>
-        <directory>vendor/silverstripe/spamprotection/tests</directory>
-        <directory>vendor/silverstripe/akismet/tests</directory>
-        <directory>vendor/silverstripe/comments/tests</directory>
-        <directory>vendor/silverstripe/comment-notifications/tests</directory>
-        <directory>vendor/colymba/gridfield-bulk-editing-tools/tests</directory>
-    </testsuite>
+        <testsuite name="recipe-blog">
+            <directory>vendor/silverstripe/blog/tests</directory>
+            <directory>vendor/silverstripe/lumberjack/tests</directory>
+            <directory>vendor/silverstripe/widgets/tests</directory>
+            <directory>vendor/silverstripe/content-widget/tests</directory>
+            <directory>vendor/silverstripe/spamprotection/tests</directory>
+            <directory>vendor/silverstripe/akismet/tests</directory>
+            <directory>vendor/silverstripe/comments/tests</directory>
+            <directory>vendor/silverstripe/comment-notifications/tests</directory>
+        </testsuite>
 
-    <testsuite name="recipe-collaboration">
-        <directory>vendor/silverstripe/contentreview/tests</directory>
-        <directory>vendor/silverstripe/sharedraftcontent/tests</directory>
-        <directory>vendor/symbiote/silverstripe-advancedworkflow/tests</directory>
-    </testsuite>
+        <testsuite name="recipe-collaboration">
+            <directory>vendor/silverstripe/contentreview/tests</directory>
+            <directory>vendor/silverstripe/sharedraftcontent/tests</directory>
+            <directory>vendor/symbiote/silverstripe-advancedworkflow/tests</directory>
+        </testsuite>
 
-    <testsuite name="recipe-content-blocks">
-        <directory>vendor/dnadesign/silverstripe-elemental/tests</directory>
-        <directory>vendor/dnadesign/silverstripe-elemental-subsites/tests</directory>
-        <directory>vendor/dnadesign/silverstripe-elemental-userforms/tests</directory>
-        <directory>vendor/silverstripe/elemental-fileblock/tests</directory>
-        <directory>vendor/silverstripe/elemental-bannerblock/tests</directory>
-        <directory>vendor/silverstripe/versioned-admin/tests</directory>
-    </testsuite>
+        <testsuite name="recipe-content-blocks">
+            <directory>vendor/dnadesign/silverstripe-elemental/tests</directory>
+            <directory>vendor/dnadesign/silverstripe-elemental-userforms/tests</directory>
+            <directory>vendor/silverstripe/elemental-fileblock/tests</directory>
+            <directory>vendor/silverstripe/elemental-bannerblock/tests</directory>
+            <directory>vendor/silverstripe/versioned-admin/tests</directory>
+        </testsuite>
 
-    <testsuite name="recipe-form-building">
-        <directory>vendor/silverstripe/segment-field/tests</directory>
-        <directory>vendor/silverstripe/userforms/tests</directory>
-        <directory>vendor/symbiote/silverstripe-queuedjobs/tests</directory>
-    </testsuite>
+        <testsuite name="recipe-form-building">
+            <directory>vendor/silverstripe/segment-field/tests</directory>
+            <directory>vendor/silverstripe/userforms/tests</directory>
+            <directory>vendor/symbiote/silverstripe-queuedjobs/tests</directory>
+        </testsuite>
 
-    <testsuite name="recipe-reporting-tools">
-        <directory>vendor/silverstripe/externallinks/tests</directory>
-        <directory>vendor/silverstripe/reports/tests</directory>
-        <directory>vendor/silverstripe/securityreport/tests</directory>
-        <directory>vendor/silverstripe/sitewidecontent-report/tests</directory>
-        <directory>vendor/bringyourownideas/silverstripe-maintenance/tests</directory>
-        <directory>vendor/bringyourownideas/silverstripe-composer-update-checker/tests</directory>
-        <directory>vendor/bringyourownideas/silverstripe-composer-security-checker/tests</directory>
-    </testsuite>
+        <testsuite name="recipe-reporting-tools">
+            <directory>vendor/silverstripe/externallinks/tests</directory>
+            <directory>vendor/silverstripe/reports/tests</directory>
+            <directory>vendor/silverstripe/securityreport/tests</directory>
+            <directory>vendor/silverstripe/sitewidecontent-report/tests</directory>
+            <directory>vendor/bringyourownideas/silverstripe-maintenance/tests</directory>
+            <directory>vendor/bringyourownideas/silverstripe-composer-update-checker/tests</directory>
+        </testsuite>
 
-    <testsuite name="recipe-services">
-        <directory>vendor/silverstripe/restfulserver/tests</directory>
-        <directory>vendor/silverstripe/versionfeed/tests</directory>
-    </testsuite>
+        <testsuite name="recipe-services">
+            <directory>vendor/silverstripe/restfulserver/tests</directory>
+            <directory>vendor/silverstripe/versionfeed/tests</directory>
+        </testsuite>
 
-    <testsuite name="optional-authenticators">
-        <directory>vendor/silverstripe/ldap/tests</directory>
-        <directory>vendor/silverstripe/realme/tests</directory>
-    </testsuite>
+        <testsuite name="optional-authenticators">
+            <directory>vendor/silverstripe/ldap/tests</directory>
+            <directory>vendor/silverstripe/realme/tests</directory>
+        </testsuite>
 
-    <testsuite name="mfa">
-        <directory>vendor/silverstripe/mfa/tests</directory>
-        <directory>vendor/silverstripe/totp-authenticator/tests</directory>
-        <directory>vendor/silverstripe/webauthn-authenticator/tests</directory>
-        <directory>vendor/silverstripe/login-forms/tests</directory>
-        <directory>vendor/silverstripe/security-extensions/tests</directory>
-    </testsuite>
+        <testsuite name="mfa">
+            <directory>vendor/silverstripe/mfa/tests</directory>
+            <directory>vendor/silverstripe/totp-authenticator/tests</directory>
+            <directory>vendor/silverstripe/webauthn-authenticator/tests</directory>
+            <directory>vendor/silverstripe/login-forms/tests</directory>
+            <directory>vendor/silverstripe/security-extensions/tests</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,12 +36,12 @@
 
         <!-- Optional CWP modules that aren't in recipes -->
         <testsuite name="Default">
-            <directory>mysite/tests</directory>
             <directory>vendor/cwp/agency-extensions/tests</directory>
             <directory>vendor/silverstripe/subsites/tests</directory>
             <directory>vendor/silverstripe/ckan-registry/tests</directory>
             <directory>vendor/silverstripe/crontask/tests</directory>
             <directory>vendor/silverstripe/gridfieldqueuedexport/tests</directory>
+            <directory>vendor/silverstripe/errorpage/tests</directory>
             <directory>vendor/silverstripe/registry/tests</directory>
             <directory>vendor/silverstripe/textextraction/tests</directory>
             <directory>vendor/tractorcow/silverstripe-fluent/tests</directory>


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/503

- Adds testsuites node for phpunit 9
- Remove vendor/symbiote/silverstripe-errorpage/tests
- Remove vendor/colymba/gridfield-bulk-editing-tools/tests
- Remove vendor/dnadesign/silverstripe-elemental-subsites/tests
- Remove vendor/bringyourownideas/silverstripe-composer-security-checker/tests