### PR TITLE
MNT Define which file should be copied to project when recipe is installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,12 +48,14 @@
         "silverstripe/recipe-testing": "^2",
         "mikey179/vfsstream": "^1.6"
     },
-    "replace": {
-        "sminnee/phpunit": "*",
-        "sminnee/phpunit-mock-objects": "*"
-    },
     "extra": {
-        "project-files": []
+        "project-files": [
+            "app/*"
+        ],
+        "public-files": [
+            "assets/*",
+            "favicon.ico"
+        ]
     },
     "config": {
         "process-timeout": 600

--- a/public/.gitignore
+++ b/public/.gitignore
@@ -1,1 +1,2 @@
+/_resources/
 /resources/


### PR DESCRIPTION
The recipe is missing the special statements to get the recipe files installed on your project.



# Parent issue
- https://github.com/silverstripeltd/product-issues/issues/428