### PR TITLE
MNT Add composer plugins to allow-plugins by default.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,12 @@
         ]
     },
     "config": {
-        "process-timeout": 600
+        "process-timeout": 600,
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/recipe-plugin": true,
+            "silverstripe/vendor-plugin": true
+        }
     },
     "prefer-stable": true,
     "minimum-stability": "dev"


### PR DESCRIPTION
These plugins are always required for kitchen sink installs, so we should allow them by default.

## Parent Issue
- silverstripeltd/product-issues#528