### PR TITLE
MNT Fix constraint for frameworktest.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "tractorcow/silverstripe-fluent": "4.6.x-dev"
     },
     "require-dev": {
-        "silverstripe/frameworktest": "4.x-dev",
+        "silverstripe/frameworktest": "^0.4.4",
         "silverstripe/graphql-devtools": "1.x-dev",
         "silverstripe/recipe-testing": "^2",
         "mikey179/vfsstream": "^1.6"


### PR DESCRIPTION
There is no `4` branch or branch alias for frameworktest. That is the old branch, but it doesn't exist anymore.

After merging this PR, merge up to `4`.