### PR TITLE
MNT Use php7.3 compatible version for frameworktest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "tractorcow/silverstripe-fluent": "4.6.x-dev"
     },
     "require-dev": {
-        "silverstripe/frameworktest": "^0.4.5",
+        "silverstripe/frameworktest": "^0.4.6",
         "silverstripe/graphql-devtools": "1.x-dev",
         "silverstripe/recipe-testing": "^2",
         "mikey179/vfsstream": "^1.6"


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Use https://github.com/silverstripe/silverstripe-frameworktest/releases/tag/0.4.6

Fix prefer-lowest https://github.com/silverstripe/recipe-kitchen-sink/runs/7459666112?check_suite_focus=true#step:10:84
`PHP Parse error:  syntax error, unexpected 'string' (T_STRING), expecting function (T_FUNCTION) or const (T_CONST) in /home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/silverstripe/frameworktest/code/elemental/ElementalBehatTestAdmin.php on line 10`