### PR TITLE
MNT Use php 7.4 for prefer-lowest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       # This should be php 7.3 & 8.0 in 4.10, and php 7.4 & 8.1 in 4.11+
       # Run recipe-cms testsuite because that's the most likely to have weird conflicts e.g. graphql
       extra_jobs: |
-        - php: 7.3
+        - php: 7.4
           composer_args: --prefer-lowest
           phpunit: true
           phpunit_suite: recipe-cms


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Fix https://github.com/silverstripe/recipe-kitchen-sink/runs/7512733988?check_suite_focus=true
`Problem 1
    - Root composer.json requires php ^7.4 || ^8.0 but your php version (7.3; overridden via config.platform, actual: 7.3.33) does not satisfy that requirement.`