### PR TITLE
DEP Use caret for silverstripe/recipe-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.1",
-        "silverstripe/recipe-plugin": "2.x-dev",
+        "silverstripe/recipe-plugin": "^2",
         "silverstripe/installer": "5.x-dev",
         "silverstripe/recipe-authoring-tools": "2.x-dev",
         "silverstripe/recipe-blog": "2.x-dev",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -122,7 +122,6 @@
             <directory>vendor/silverstripe/totp-authenticator/tests</directory>
             <directory>vendor/silverstripe/webauthn-authenticator/tests</directory>
             <directory>vendor/silverstripe/login-forms/tests</directory>
-            <directory>vendor/silverstripe/security-extensions/tests</directory>
         </testsuite>
 
     </testsuites>


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-installer/issues/341

Note CMS 4 does define recipe-plugin even though silverstripe/installer does - https://github.com/silverstripe/recipe-kitchen-sink/blob/4/composer.json#L9 - 

This is possibly because it needs to load "before" other things, I'm not sure. It's fairly harmless leaving it here regardless

Failing unit tests are unrelated