### PR TITLE
DEP Stop using the fork of fluent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symbiote/silverstripe-multivaluefield": "6.0.x-dev",
         "symbiote/silverstripe-gridfieldextensions": "4.0.x-dev",
         "colymba/gridfield-bulk-editing-tools": "4.0.x-dev",
-        "silverstripe/silverstripe-fluent": "7.0.x-dev",
+        "tractorcow/silverstripe-fluent": "7.0.x-dev",
         "silverstripe/dynamodb": "5.0.x-dev"
     },
     "require-dev": {


### PR DESCRIPTION
The changes in our forked repo have been folded back into the main repo, with appropriate branches and tags created.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/690