### PR TITLE
MNT Move security-extensions into its own test suite

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -124,8 +124,10 @@
             <directory>vendor/silverstripe/totp-authenticator/tests</directory>
             <directory>vendor/silverstripe/webauthn-authenticator/tests</directory>
             <directory>vendor/silverstripe/login-forms/tests</directory>
-            <directory>vendor/silverstripe/security-extensions/tests</directory>
         </testsuite>
 
+        <testsuite name="other">
+            <directory>vendor/silverstripe/security-extensions/tests</directory>
+        </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/4304902930/jobs/7506597508
> PHP Fatal error:  Maximum execution time of 60 seconds exceeded in /home/runner/work/recipe-kitchen-sink/recipe-kitchen-sink/vendor/silverstripe/framework/src/Core/ClassInfo.php on line 198

The individual tests all run fine, but for whatever reason several combinations of the tests in the mfa testsuite result in timing out. This combination doesn't time out, and it's what we've got in cms 5 as well (since cms 5 doesn't have security extensions).

Targetting 4.12 instead of 4 so we are running the same tests for our current and next minors.

## Parent issue
- https://github.com/silverstripe/.github/issues/6