### PR TITLE
MNT Update extra_jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,12 @@ jobs:
       simple_matrix: true
       # Also include jobs with the lowest version of PHP with --prefer-lowest and
       # the highest version of PHP to ensure everything installs
-      # This should be php 7.3 & 8.0 in 4.10, and php 7.4 & 8.1 in 4.11+
       # Run recipe-cms testsuite because that's the most likely to have weird conflicts e.g. graphql
       extra_jobs: |
         - php: 8.1
+          composer_args: --prefer-lowest
           phpunit: true
           phpunit_suite: recipe-cms
-      # TODO: renable prefer-lowest build once CMS 5 beta is out
-      # - php: 8.1
-      #   composer_args: --prefer-lowest
-      #   phpunit: true
-      #   phpunit_suite: recipe-cms
+        - php: 8.2
+          phpunit: true
+          phpunit_suite: recipe-cms


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/677

Note: `--prefer-lowest` is turned on globally for CMS 5 builds, this one needs it (and the PHP 8.2 job) added via extra_jobs because of the use of `simple_matrix: true`

Broken unit test is unrelated
