### PR TITLE
MNT Don't accidentally skip framework tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,14 +13,10 @@
             <directory>vendor/silverstripe/framework/tests/php/ORM</directory>
         </testsuite>
         <testsuite name="framework-core">
-            <directory>vendor/silverstripe/framework/tests/php/Control</directory>
-            <directory>vendor/silverstripe/framework/tests/php/Core</directory>
-            <directory>vendor/silverstripe/framework/tests/php/Dev</directory>
-            <directory>vendor/silverstripe/framework/tests/php/Forms</directory>
-            <directory>vendor/silverstripe/framework/tests/php/Logging</directory>
-            <directory>vendor/silverstripe/framework/tests/php/Security</directory>
-            <directory>vendor/silverstripe/framework/tests/php/View</directory>
-            <directory>vendor/silverstripe/framework/tests/php/i18n</directory>
+            <directory>vendor/silverstripe/framework/tests/php</directory>
+            <exclude>
+                <directory>vendor/silverstripe/framework/tests/php/ORM</directory>
+            </exclude>
         </testsuite>
 
         <testsuite name="recipe-cms">


### PR DESCRIPTION
If we added a new directory under framework/tests/php we would likely _not_ remember to add it to this list - so lets just include everything that isn't ORM instead.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10900