### PR TITLE
MNT Add supported modules that cow can't find

### DIFF
--- a/.cow.json
+++ b/.cow.json
@@ -27,9 +27,6 @@
     "dnadesign"
   ],
   "upgrade-only": [
-    "colymba/gridfield-bulk-editing-tools",
-    "tractorcow/silverstripe-fluent",
-    "silverstripe/recipe-plugin",
-    "silverstripe/vendor-plugin"
+    "tractorcow/silverstripe-fluent"
   ]
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,10 @@
         "silverstripe/recipe-reporting-tools": "2.x-dev",
         "silverstripe/recipe-services": "2.x-dev",
         "silverstripe/recipe-content-blocks": "3.x-dev",
+        "silverstripe/auditor": "3.x-dev",
         "silverstripe/developer-docs": "5.x-dev",
+        "silverstripe/environmentcheck": "3.x-dev",
+        "silverstripe/hybridsessions": "3.x-dev",
         "silverstripe/registry": "3.x-dev",
         "silverstripe/totp-authenticator": "5.x-dev",
         "silverstripe/mfa": "5.x-dev",
@@ -34,6 +37,7 @@
         "dnadesign/silverstripe-elemental-userforms": "4.x-dev",
         "symbiote/silverstripe-multivaluefield": "6.x-dev",
         "symbiote/silverstripe-gridfieldextensions": "4.x-dev",
+        "symbiote/silverstripe-queuedjobs": "5.x-dev",
         "colymba/gridfield-bulk-editing-tools": "4.x-dev",
         "tractorcow/silverstripe-fluent": "7.x-dev",
         "silverstripe/dynamodb": "5.x-dev"


### PR DESCRIPTION
These modules are included when installing via composer, but cow can't find a path to them because no recipe directly references them.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/803