### PR TITLE
DEP Remove cwp/agency-extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "silverstripe/lumberjack": "4.x-dev",
         "silverstripe/staticpublishqueue": "7.x-dev",
         "cwp/starter-theme": "5.x-dev",
-        "cwp/agency-extensions": "4.x-dev",
         "cwp/watea-theme": "5.x-dev",
         "dnadesign/silverstripe-elemental-userforms": "5.x-dev",
         "symbiote/silverstripe-multivaluefield": "7.x-dev",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/199

There is no CMS 6 version of cwp/cwp which means cwp/agency-extensions will never be CMS 6 compatible, so we're simply removing it from sink

CI failures are existing and unrelated to this PR