### PR TITLE
MNT Fix changelog dir

### DIFF
--- a/.cow.json
+++ b/.cow.json
@@ -1,7 +1,7 @@
 {
   "github-slug": "silverstripe/recipe-kitchen-sink",
   "changelog-holder": "silverstripe/developer-docs",
-  "changelog-path": "en/04_Changelogs/{stability}/{version}.md",
+  "changelog-path": "en/08_Changelogs/{stability}/{version}.md",
   "changelog-template": ".cow/changelog.md.twig",
   "changelog-include-other-changes": false,
   "child-stability-inherit": [


### PR DESCRIPTION
Missed when https://github.com/silverstripe/.github/issues/210 was done.

Targetting the `5.2` branch so it can be correct when we do the 5.2.0 stable release.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/852