### PR TITLE
MNT Fluent is no longer upgrade-only for releases

### DIFF
--- a/.cow.json
+++ b/.cow.json
@@ -27,6 +27,5 @@
     "dnadesign"
   ],
   "upgrade-only": [
-    "tractorcow/silverstripe-fluent"
   ]
 }


### PR DESCRIPTION
Steve and I both have access to tag fluent now, so we can let cow do the heavy lifting.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/876