### PR TITLE
MNT Add silverstripe/silverstripe-template-engine tests to test suite

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
             <directory>vendor/silverstripe/config/tests</directory>
             <directory>vendor/silverstripe/assets/tests/php/</directory>
             <directory>vendor/silverstripe/versioned/tests/php/</directory>
+            <directory>vendor/silverstripe/template-engine/tests/php/</directory>
         </testsuite>
 
         <!-- Framework ORM tests are split up to run in parallel -->


### PR DESCRIPTION
Adds the new module to a test suite in kitchen sink so it gets included in kitchen sink runs.

NOTE: The CI for this won't go green one of the other PRs that adds the dependency gets merged.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11322