### PR TITLE
MNT Include colymba in releases

### DIFF
--- a/.cow.json
+++ b/.cow.json
@@ -14,7 +14,8 @@
     "silverstripe",
     "tractorcow",
     "symbiote",
-    "dnadesign"
+    "dnadesign",
+    "colymba"
   ],
   "upgrade-only": [
   ]


### PR DESCRIPTION
`silverstripe` is the organisation the repo is in for GitHub references, but the composer reference still uses `colymba`.
## Issue
- https://github.com/silverstripe/.github/issues/340