### PR TITLE
FIX Remove unnecessary theme.yml file.

### DIFF
--- a/app/_config/theme.yml
+++ b/app/_config/theme.yml
@@ -1,8 +1,0 @@
----
-Name: theme
----
-SilverStripe\View\SSViewer:
-  themes:
-    - '$public'
-    - 'simple'
-    - '$default'


### PR DESCRIPTION
This file is currently identical to the one in installer, but will clash with it after silverstripe/silverstripe-installer#384 is merged.

The file used to be needed because it replaced `simple` with the CWP themes.

## Issue
- https://github.com/silverstripe/startup-theme/issues/7