### PR TITLE
MNT Add new TinyMCE module test suites.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,10 @@ jobs:
           endtoend_tags: job3,job4,job5,job6
         - php: 8.3
           endtoend: true
+          endtoend_suite: htmleditor-tinymce
+          endtoend_config: vendor/silverstripe/htmleditor-tinymce/behat.yml
+        - php: 8.3
+          endtoend: true
           endtoend_suite: linkfield
           endtoend_config: vendor/silverstripe/linkfield/behat.yml
           endtoend_tags: job1

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -37,6 +37,7 @@
 
         <testsuite name="g2">
             <directory>vendor/silverstripe/campaign-admin/tests/php/</directory>
+            <directory>vendor/silverstripe/htmleditor-tinymce/tests/php</directory>
             <directory>vendor/silverstripe/hybridsessions/tests</directory>
             <directory>vendor/silverstripe/tagfield/tests</directory>
             <directory>vendor/silverstripe/taxonomy/tests</directory>


### PR DESCRIPTION
The module itself will be added as a dependency of installer, so we don't need to update the dependencies of sink.

## Issue
- https://github.com/silverstripe/silverstripe-htmleditor-tinymce/issues/2